### PR TITLE
Add Modbus server and client examples

### DIFF
--- a/modbusclient_sample.py
+++ b/modbusclient_sample.py
@@ -1,0 +1,161 @@
+# final_client.py
+
+from flask import Flask, jsonify, render_template_string, request
+from pymodbus.client import ModbusTcpClient
+
+# --- Modbus 클라이언트 함수 ---
+def read_registers(client, unit_id, fc, address, count):
+    """Modbus 읽기 요청을 처리하는 범용 함수"""
+    read_map = {
+        2: client.read_discrete_inputs,
+        3: client.read_holding_registers,
+    }
+    func = read_map.get(fc)
+    if not func:
+        return None, f"지원하지 않는 Function Code: {fc}"
+
+    response = func(address, count=count, slave=unit_id)
+    if response.isError():
+        return None, f"읽기 오류: {response}"
+
+    return response.registers if fc == 3 else response.bits[:count], None
+
+def write_coil_register(client, unit_id, address, value):
+    """코일 쓰기 요청을 처리하는 함수"""
+    response = client.write_coil(address, value, slave=unit_id)
+    if response.isError():
+        return False, f"쓰기 오류: {response}"
+    return True, None
+
+# --- Flask 라우트 ---
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template_string(HTML_PAGE)
+
+@app.route('/api/data', methods=['GET'])
+def get_data():
+    client = ModbusTcpClient("127.0.0.1", port=5020, timeout=2)
+    if not client.connect():
+        return jsonify({"error": "서버 연결 실패"}), 500
+
+    try:
+        hr1, err1 = read_registers(client, 1, 3, 0, 5)
+        di1, err2 = read_registers(client, 1, 2, 0, 5)
+        hr2, err3 = read_registers(client, 2, 3, 0, 5)
+        di2, err4 = read_registers(client, 2, 2, 0, 5)
+
+        if any([err1, err2, err3, err4]):
+            return jsonify({"error": f"{err1 or err2 or err3 or err4}"}), 500
+
+        return jsonify({
+            "registers_1": hr1, "inputs_1": di1,
+            "registers_2": hr2, "inputs_2": di2,
+        })
+    finally:
+        client.close()
+
+@app.route('/api/write_coil', methods=['POST'])
+def set_coil():
+    try:
+        unit_id = int(request.args.get('unitId'))
+        address = int(request.args.get('address'))
+        value = bool(int(request.args.get('value')))
+    except (TypeError, ValueError):
+        return jsonify({"error": "잘못된 파라미터"}), 400
+
+    client = ModbusTcpClient("127.0.0.1", port=5020, timeout=2)
+    if not client.connect():
+        return jsonify({"error": "서버 연결 실패"}), 500
+
+    try:
+        success, error = write_coil_register(client, unit_id, address, value)
+        if not success:
+            return jsonify({"error": error}), 500
+        return jsonify({"success": True}), 200
+    finally:
+        client.close()
+
+# --- 웹페이지 HTML & JavaScript ---
+HTML_PAGE = """
+<!doctype html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8">
+    <title>HVAC 제어 시스템</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; display: flex; flex-direction: column; align-items: center; background-color: #f0f2f5; margin: 0; }
+        h3 { margin: 20px 0; color: #1f2937; }
+        table { width: 95%; max-width: 1000px; border-collapse: collapse; text-align: center; background-color: white; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); border-radius: 8px; overflow: hidden; }
+        th, td { padding: 12px 15px; }
+        thead { background-color: #4f46e5; color: white; }
+        tbody tr:nth-child(even) { background-color: #f8f9fa; }
+        tbody tr:hover { background-color: #e9ecef; }
+        button { padding: 6px 12px; margin: 0 4px; border: none; border-radius: 6px; cursor: pointer; font-weight: 600; transition: all 0.2s ease-in-out; }
+        .on-button { background-color: #22c55e; color: white; } .on-button:hover { background-color: #16a34a; }
+        .off-button { background-color: #ef4444; color: white; } .off-button:hover { background-color: #dc2626; }
+    </style>
+<script>
+    async function fetchData() {
+        try {
+            const response = await fetch('/api/data');
+            const data = await response.json();
+            if (data.error) {
+                console.error("API Error:", data.error);
+                return;
+            }
+            updateTable(data);
+        } catch (error) {
+            console.error('Fetch Error:', error);
+        }
+    }
+
+    function updateTable(data) {
+        const tableBody = document.getElementById('modbus-table-body');
+        const allRegisters = (data.registers_1 || []).concat(data.registers_2 || []);
+        const allInputs = (data.inputs_1 || []).concat(data.inputs_2 || []);
+        let tableHTML = '';
+
+        for (let i = 0; i < 10; i++) {
+            const unitId = i < 5 ? 1 : 2;
+            const address = i % 5;
+            const temp = allRegisters[i] ?? 'N/A';
+            const status = typeof allInputs[i] === 'boolean' ? (allInputs[i] ? '🟢 ON' : '🔴 OFF') : 'N/A';
+            const alertIcon = temp >= 28 ? '🚨' : '';
+
+            tableHTML += `
+                <tr>
+                    <td>에어컨 ${i + 1}</td>
+                    <td>${temp} ${alertIcon}</td>
+                    <td>${status}</td>
+                    <td>
+                        <button class="on-button" onclick="writeCoil(${unitId}, ${address}, 1)">ON</button>
+                        <button class="off-button" onclick="writeCoil(${unitId}, ${address}, 0)">OFF</button>
+                    </td>
+                </tr>`;
+        }
+        tableBody.innerHTML = tableHTML;
+    }
+
+    async function writeCoil(unitId, address, value) {
+        await fetch(`/api/write_coil?unitId=${unitId}&address=${address}&value=${value}`, { method: 'POST' });
+        setTimeout(fetchData, 200); // 쓰기 후 0.2초 뒤에 데이터 즉시 갱신
+    }
+
+    setInterval(fetchData, 2500); // 2.5초마다 데이터 자동 갱신
+    window.onload = fetchData;
+</script>
+</head>
+<body>
+    <h3>HVAC 제어 시스템</h3>
+    <table>
+        <thead><tr><th>장치</th><th>온도 (°C)</th><th>상태</th><th>명령</th></tr></thead>
+        <tbody id="modbus-table-body"></tbody>
+    </table>
+</body>
+</html>
+"""
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/modserver_sample.py
+++ b/modserver_sample.py
@@ -1,0 +1,78 @@
+# final_server_6reg.py
+
+import logging
+import threading
+import time
+from pymodbus.datastore import (ModbusSequentialDataBlock, ModbusServerContext,
+                                ModbusSlaveContext)
+from pymodbus.device import ModbusDeviceIdentification
+from pymodbus.server import StartTcpServer
+
+logging.basicConfig()
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+
+data_lock = threading.Lock()
+
+# [수정] 모든 데이터 블록의 크기를 6으로 변경
+db1_hr = ModbusSequentialDataBlock(0, [15] * 6)
+db1_co = ModbusSequentialDataBlock(0, [False] * 6)
+db1_di = ModbusSequentialDataBlock(0, [False] * 6)
+
+db2_hr = ModbusSequentialDataBlock(0, [15] * 6)
+db2_co = ModbusSequentialDataBlock(0, [False] * 6)
+db2_di = ModbusSequentialDataBlock(0, [False] * 6)
+
+context = ModbusServerContext(
+    slaves={
+        1: ModbusSlaveContext(di=db1_di, co=db1_co, hr=db1_hr),
+        2: ModbusSlaveContext(di=db2_di, co=db2_co, hr=db2_hr),
+    },
+    single=False,
+)
+
+identity = ModbusDeviceIdentification()
+identity.VendorName = 'Gemini 6-Reg Test'
+identity.ProductName = '6-Register Test Server'
+
+def update_discrete_inputs_thread(update_interval=0.5):
+    datablocks = [{'co': db1_co, 'di': db1_di}, {'co': db2_co, 'di': db2_di}]
+    while True:
+        with data_lock:
+            for db in datablocks:
+                # [수정] 6개 읽기
+                coil_vals = db['co'].getValues(0, count=6)
+                db['di'].setValues(0, coil_vals)
+        time.sleep(update_interval)
+
+def update_temperature_thread(update_interval=2):
+    datablocks = [{'hr': db1_hr, 'di': db1_di}, {'hr': db2_hr, 'di': db2_di}]
+    while True:
+        with data_lock:
+            for db in datablocks:
+                # [수정] 6개 읽기
+                hr_vals = db['hr'].getValues(0, count=6)
+                di_vals = db['di'].getValues(0, count=6)
+
+                # [수정] 6개 확인
+                if len(hr_vals) == 6 and len(di_vals) == 6:
+                    # [수정] 6번 반복
+                    for i in range(6):
+                        if di_vals[i]:
+                            if hr_vals[i] > 7: hr_vals[i] -= 1
+                        else:
+                            if hr_vals[i] < 30: hr_vals[i] += 1
+                    db['hr'].setValues(0, hr_vals)
+        time.sleep(update_interval)
+
+def run_server():
+    thread1 = threading.Thread(target=update_discrete_inputs_thread, daemon=True)
+    thread2 = threading.Thread(target=update_temperature_thread, daemon=True)
+    thread1.start()
+    thread2.start()
+
+    log.info(f"Modbus 서버 (6-레지스터 모드)를 시작합니다. 포트: 5020")
+    StartTcpServer(context=context, identity=identity, address=("0.0.0.0", 5020))
+
+if __name__ == "__main__":
+    run_server()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+blinker==1.9.0
+click==8.2.1
+Flask==3.1.1
+itsdangerous==2.2.0
+Jinja2==3.1.6
+MarkupSafe==3.0.2
+pymodbus==3.9.2
+Werkzeug==3.1.3


### PR DESCRIPTION
This commit introduces two new Python files:
- modserver_sample.py: A Modbus TCP server that simulates an HVAC system with 6 registers.
- modbusclient_sample.py: A Flask web application that acts as a Modbus TCP client to interact with the server, allowing you to monitor and control the simulated HVAC units.

Additionally, a requirements.txt file is included to list the necessary Python dependencies for running these examples.